### PR TITLE
[ln882h] Fix flashing with .bin/raw file

### DIFF
--- a/ltchiptool/soc/ln882h/util/ln882htool.py
+++ b/ltchiptool/soc/ln882h/util/ln882htool.py
@@ -208,7 +208,7 @@ class LN882hTool(SerialToolBase):
 
         # Convert stream to temporary file before sending with YMODEM
         with NamedTemporaryFile(delete=False) as f:
-            f.write(stream.getbuffer())
+            f.write(stream.read())
 
         self.command(f"upgrade", waitresp=False)
 


### PR DESCRIPTION
stream.getbuffer() is only available on BytesIO, not IO[bytes]. This causes a failure when writing flash when reading from a regular BufferedReader (such as in a raw/.bin file using -f -s)

.read is available on IO[bytes] which BufferedReader and BytesIO both implement. 